### PR TITLE
Propagate prompt overrides to responses pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,8 @@ ChatBot.init({
 </script>
 ```
 
+> **Tip:** Any values supplied in `responsesConfig` are forwarded with each `/chat-unified.php` request. For example, `promptId` automatically becomes `prompt_id` in the payload so the PHP endpoint can target the correct saved prompt version.
+
 ### File Upload Configuration
 
 ```javascript
@@ -252,7 +254,7 @@ return [
 |--------|------|---------|-------------|
 | `apiType` | string | `'responses'` | API to use: `'chat'` or `'responses'` |
 | `enableFileUpload` | boolean | `false` | Enable file upload functionality |
-| `responsesConfig` | object | `{}` | Responses API prompt reference settings |
+| `responsesConfig` | object | `{}` | Responses API prompt reference settings forwarded as `prompt_id` / `prompt_version` |
 
 #### Callbacks
 
@@ -279,6 +281,8 @@ Unified endpoint supporting both APIs.
     "message": "Hello",
     "conversation_id": "conv_123",
     "api_type": "responses",
+    "prompt_id": "pmpt_your_prompt_id",
+    "prompt_version": "1",
     "file_data": [
         {
             "name": "document.pdf",

--- a/chat-unified.php
+++ b/chat-unified.php
@@ -76,17 +76,23 @@ try {
     $conversationId = '';
     $apiType = $config['api_type'];
     $fileData = null;
+    $promptId = '';
+    $promptVersion = '';
 
     if ($method === 'GET') {
         $message = $_GET['message'] ?? '';
         $conversationId = $_GET['conversation_id'] ?? '';
         $apiType = $_GET['api_type'] ?? $apiType;
+        $promptId = $_GET['prompt_id'] ?? $promptId;
+        $promptVersion = $_GET['prompt_version'] ?? $promptVersion;
     } elseif ($method === 'POST') {
         $input = json_decode(file_get_contents('php://input'), true);
         $message = $input['message'] ?? '';
         $conversationId = $input['conversation_id'] ?? '';
         $apiType = $input['api_type'] ?? $apiType;
         $fileData = $input['file_data'] ?? null;
+        $promptId = $input['prompt_id'] ?? $promptId;
+        $promptVersion = $input['prompt_version'] ?? $promptVersion;
     }
 
     log_debug("Incoming request method=$method apiType=$apiType conv=$conversationId msgLen=" . strlen($message));
@@ -116,7 +122,7 @@ try {
 
     // Route to appropriate handler
     if ($apiType === 'responses') {
-        $chatHandler->handleResponsesChat($message, $conversationId, $fileData);
+        $chatHandler->handleResponsesChat($message, $conversationId, $fileData, $promptId, $promptVersion);
     } else {
         $chatHandler->handleChatCompletion($message, $conversationId);
     }

--- a/chatbot-enhanced.js
+++ b/chatbot-enhanced.js
@@ -604,6 +604,22 @@
                     api_type: this.options.apiType
                 };
 
+                if (this.options.apiType === 'responses') {
+                    const responsesConfig = this.options.responsesConfig || {};
+                    Object.entries(responsesConfig).forEach(([key, value]) => {
+                        if (value === undefined || value === null || value === '') {
+                            return;
+                        }
+
+                        const normalizedKey = key.replace(/([A-Z])/g, '_$1').toLowerCase();
+                        if (normalizedKey.length === 0) {
+                            return;
+                        }
+
+                        requestData[normalizedKey] = value;
+                    });
+                }
+
                 // Add file data if present
                 if (files.length > 0) {
                     requestData.file_data = await Promise.all(
@@ -730,6 +746,14 @@
                         conversation_id: requestData.conversation_id || '',
                         api_type: requestData.api_type || this.options.apiType || 'chat'
                     });
+
+                    if (requestData.prompt_id) {
+                        params.set('prompt_id', `${requestData.prompt_id}`);
+                    }
+
+                    if (requestData.prompt_version) {
+                        params.set('prompt_version', `${requestData.prompt_version}`);
+                    }
 
                     const url = `${this.options.apiEndpoint}?${params.toString()}`;
                     const eventSource = new EventSource(url);


### PR DESCRIPTION
## Summary
- forward responsesConfig overrides (prompt id/version) with every widget request, including SSE fallbacks
- accept prompt_id and prompt_version in chat-unified.php and prioritise them in ChatHandler before global defaults
- document request-level prompt overrides for the Responses API usage

## Testing
- php -l chat-unified.php
- php -l includes/ChatHandler.php

------
https://chatgpt.com/codex/tasks/task_e_68e6cd5f693883239c5677c41edc6942