### PR TITLE
Add GitHub Actions CI/CD pipeline

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -1,0 +1,117 @@
+name: CI/CD Pipeline
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+concurrency:
+  group: cicd-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  quality:
+    name: Quality checks
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.2'
+          extensions: curl, mbstring, json, sockets
+          coverage: none
+          tools: composer
+
+      - name: Install Composer dependencies
+        run: composer install --prefer-dist --no-progress --no-interaction
+
+      - name: Lint PHP files
+        run: |
+          find . -path './vendor' -prune -o -name '*.php' -print0 | xargs -0 -r -n1 php -l
+
+      - name: Run PHPUnit
+        if: hashFiles('tests/**') != ''
+        run: vendor/bin/phpunit --colors=always
+
+  package:
+    name: Build release artifact
+    needs: quality
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main'
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.2'
+          extensions: curl, mbstring, json
+          coverage: none
+          tools: composer
+
+      - name: Install production dependencies
+        run: composer install --no-dev --prefer-dist --no-progress --no-interaction --optimize-autoloader
+
+      - name: Inject production environment file
+        run: |
+          printf '%s' "${{ secrets.PRODUCTION_ENV }}" > .env
+
+      - name: Stage deployment files
+        run: |
+          mkdir -p build/staging
+          rsync -a \
+            --exclude '.git/' \
+            --exclude '.github/' \
+            --exclude 'docs/' \
+            --exclude 'tests/' \
+            --exclude 'Dockerfile' \
+            --exclude 'docker-compose.yml' \
+            --exclude 'build/' \
+            . build/staging/
+
+      - name: Create release archive
+        run: |
+          tar -czf chatbot-release.tar.gz -C build/staging .
+
+      - name: Upload release artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: chatbot-release
+          path: chatbot-release.tar.gz
+          if-no-files-found: error
+
+  deploy:
+    name: Deploy to production
+    needs: package
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main'
+    environment:
+      name: production
+    steps:
+      - name: Download release artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: chatbot-release
+          path: deploy
+
+      - name: Extract release archive
+        run: |
+          tar -xzf deploy/chatbot-release.tar.gz -C deploy
+          rm deploy/chatbot-release.tar.gz
+
+      - name: Publish via SFTP
+        uses: SamKirkland/FTP-Deploy-Action@v4
+        with:
+          server: ${{ secrets.DEPLOY_HOST }}
+          username: ${{ secrets.DEPLOY_USER }}
+          password: ${{ secrets.DEPLOY_PASSWORD }}
+          protocol: sftp
+          port: ${{ secrets.DEPLOY_PORT != '' && secrets.DEPLOY_PORT || '22' }}
+          local-dir: deploy
+          server-dir: ${{ secrets.DEPLOY_PATH }}
+          private-key: ${{ secrets.DEPLOY_KEY }}

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -134,6 +134,19 @@ This guide covers various deployment scenarios for the GPT Chatbot Boilerplate, 
 - **Memory**: Minimum 512MB RAM
 - **Storage**: Minimum 1GB available space
 
+### GitHub Actions Secrets for CI/CD
+
+The GitHub Actions pipeline expects the following secrets before a production deployment can be approved through the `production` environment gate:
+
+- `PRODUCTION_ENV` – multi-line contents for the `.env` file that will be injected into the release artifact.
+- `DEPLOY_HOST` – hostname or IP address of the target SFTP server.
+- `DEPLOY_USER` – SFTP username with write permissions to the deployment directory.
+- `DEPLOY_PASSWORD` or `DEPLOY_KEY` – authentication credentials for the SFTP account (only one is required).
+- `DEPLOY_PORT` – optional override for the SFTP port (defaults to `22` when omitted).
+- `DEPLOY_PATH` – remote directory where the packaged chatbot should be published.
+
+Add these secrets under **Settings → Secrets and variables → Actions** in GitHub, and require manual approval for the `production` environment so deployments are reviewed before they execute.
+
 ### Step-by-Step Production Setup
 
 1. **Server Preparation**:

--- a/docs/gpt-codex-tasks.md
+++ b/docs/gpt-codex-tasks.md
@@ -2,23 +2,17 @@
 
 ## Tasks:
 ## CI/CD pipeline tasks
-1. **Create workflow skeleton**
-   Add `.github/workflows/cicd.yml` triggered on pushes to `main` and all pull requests, with empty `quality`, `package`, and `deploy` jobs prepared for later steps.
+- [x] **Create workflow skeleton** – Added `.github/workflows/cicd.yml` triggered on pushes to `main` and all pull requests with `quality`, `package`, and `deploy` jobs.
 
-2. **Implement quality checks**
-   Configure the `quality` job to set up PHP 8.2 with required extensions, install Composer dependencies for development, lint all PHP files, and run PHPUnit when the `tests/` directory exists.
+- [x] **Implement quality checks** – `quality` job now provisions PHP 8.2, installs Composer dependencies, lints all PHP files, and conditionally runs PHPUnit when the `tests/` directory is present.
 
-3. **Build production artifact**
-   In the `package` job (only on `main`), install production dependencies with optimized autoloading, inject the `.env` content from the `PRODUCTION_ENV` secret, and stage deployable files into a temporary directory.
+- [x] **Build production artifact** – `package` job (restricted to `main`) installs optimized production dependencies, writes the `PRODUCTION_ENV` secret to `.env`, and stages deployable files into a temporary directory.
 
-4. **Publish release archive**
-   Compress the staged files into `chatbot-release.tar.gz` and upload it using `actions/upload-artifact@v4` so other jobs can reuse the bundle.
+- [x] **Publish release archive** – The staged bundle is compressed into `chatbot-release.tar.gz` and uploaded with `actions/upload-artifact@v4` for downstream jobs.
 
-5. **Deploy via SFTP**
-   Configure the `deploy` job to download the artifact, extract it, and publish the files with `SamKirkland/FTP-Deploy-Action@v4` using SFTP credentials stored in repository secrets.
+- [x] **Deploy via SFTP** – The `deploy` job downloads and extracts the artifact, then publishes it using `SamKirkland/FTP-Deploy-Action@v4` over SFTP with repository secrets.
 
-6. **Secure production environment**
-   Document required GitHub secrets—`PRODUCTION_ENV`, `DEPLOY_HOST`, `DEPLOY_USER`, `DEPLOY_PASSWORD` or `DEPLOY_KEY`, and `DEPLOY_PATH`—and gate deployment behind the `production` environment for manual approvals.
+- [x] **Secure production environment** – Documented the required GitHub secrets and noted the `production` environment approval gate in `docs/deployment.md`.
 
    
 


### PR DESCRIPTION
## Summary
- add a CI/CD workflow that runs quality checks on every push and PR, packages releases on main, and deploys via SFTP after approval
- upload the packaged release as an artifact for reuse during deployment
- document the required GitHub secrets and note the production environment approval gate while marking the tracked tasks complete

## Testing
- not run (workflow configuration only)


------
https://chatgpt.com/codex/tasks/task_e_68e6ee767b6c8323a252d058690e73c2