### PR TITLE
Handle non-stream chat requests with synchronous responses

### DIFF
--- a/chatbot-enhanced.js
+++ b/chatbot-enhanced.js
@@ -1207,10 +1207,28 @@
             }
 
             const data = await response.json();
+
+            if (!data || typeof data !== 'object') {
+                throw new Error('Invalid response payload');
+            }
+
+            if (data.error) {
+                const errorMessage = typeof data.error === 'string' ? data.error : (data.error.message || 'Unknown error');
+                throw new Error(errorMessage);
+            }
+
+            const content = typeof data.response === 'string' && data.response !== ''
+                ? data.response
+                : (typeof data.content === 'string' ? data.content : '');
+
+            if (content === '') {
+                throw new Error('Empty response payload');
+            }
+
             this.setConnectionStatus(true);
             this.addMessage({
                 role: 'assistant',
-                content: data.response || data.content,
+                content,
                 timestamp: new Date(),
                 apiType: this.options.apiType
             });

--- a/includes/OpenAIClient.php
+++ b/includes/OpenAIClient.php
@@ -143,6 +143,10 @@ class OpenAIClient {
         return $this->makeRequest('POST', '/responses', $payload);
     }
 
+    public function createChatCompletion(array $payload) {
+        return $this->makeRequest('POST', '/chat/completions', $payload);
+    }
+
     public function submitResponseToolOutputs($responseId, array $toolOutputs) {
         return $this->makeRequest('POST', '/responses/' . $responseId . '/submit_tool_outputs', [
             'tool_outputs' => $toolOutputs,


### PR DESCRIPTION
## Summary
- detect the `stream` flag before sending SSE headers and fall back to JSON responses when disabled
- add synchronous chat completion and responses handlers to assemble full replies and reuse in the AJAX path
- validate AJAX payloads before updating UI connection status

## Testing
- php -l chat-unified.php
- php -l includes/ChatHandler.php
- php -l includes/OpenAIClient.php

------
https://chatgpt.com/codex/tasks/task_e_68e6fe1f2c2883238a0868870554904a