### PR TITLE
Fix FTP deploy action version

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -105,7 +105,7 @@ jobs:
           rm deploy/chatbot-release.tar.gz
 
       - name: Publish via SFTP
-        uses: SamKirkland/FTP-Deploy-Action@v4
+        uses: SamKirkland/FTP-Deploy-Action@v4.3.5
         with:
           server: ${{ secrets.DEPLOY_HOST }}
           username: ${{ secrets.DEPLOY_USER }}


### PR DESCRIPTION
## Summary
- point the FTP deploy step to the published v4.3.5 tag of SamKirkland/FTP-Deploy-Action to resolve the CI failure

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e784f66bf0832386a9557169c5f883