### PR TITLE
Fix Responses API history content types

### DIFF
--- a/includes/ChatHandler.php
+++ b/includes/ChatHandler.php
@@ -500,11 +500,20 @@ class ChatHandler {
 
         foreach ($messages as $message) {
             $content = $message['content'] ?? '';
+            $role = $message['role'];
+
+            $type = 'input_text';
+            if ($role === 'assistant') {
+                $type = 'output_text';
+            } elseif ($role === 'tool') {
+                $type = 'tool_result';
+            }
+
             $formattedMessage = [
-                'role' => $message['role'],
+                'role' => $role,
                 'content' => [
                     [
-                        'type' => 'input_text',
+                        'type' => $type,
                         'text' => $content
                     ]
                 ]


### PR DESCRIPTION
## Summary
- ensure assistant and tool messages use the appropriate content types when formatting history for the Responses API to prevent 400 errors on follow-up turns

## Testing
- php -l includes/ChatHandler.php

------
https://chatgpt.com/codex/tasks/task_e_68ed6aa74630832388d8b600f709f4b4