### PR TITLE
Fix admin API authentication header handling

### DIFF
--- a/public/admin/admin.js
+++ b/public/admin/admin.js
@@ -17,9 +17,13 @@ class AdminAPI {
     async request(action, options = {}) {
         const url = `${API_ENDPOINT}?action=${action}${options.params || ''}`;
         const headers = {
-            'Authorization': `Bearer ${this.token}`,
             'Content-Type': 'application/json',
         };
+
+        if (this.token) {
+            headers['Authorization'] = `Bearer ${this.token}`;
+            headers['X-Admin-Token'] = this.token;
+        }
 
         const config = {
             method: options.method || 'GET',


### PR DESCRIPTION
## Summary
- update the admin authentication routine to normalize headers, accept the X-Admin-Token fallback, and return clearer errors when tokens are missing
- adjust the admin UI client to only send an Authorization header when a token exists and mirror it in a new X-Admin-Token header

## Testing
- php -l admin-api.php

------
https://chatgpt.com/codex/tasks/task_e_690b6c469fc48323b0ed9f86181b435f