### PR TITLE
Add admin token prompt and auth header handling in admin UI

### DIFF
--- a/public/admin/admin.css
+++ b/public/admin/admin.css
@@ -434,6 +434,18 @@ tr:hover {
     color: var(--text-secondary);
 }
 
+.sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+}
+
 /* Token Modal */
 .token-modal {
     position: fixed;
@@ -467,6 +479,10 @@ tr:hover {
     border: 1px solid var(--border-color);
     border-radius: 0.375rem;
     font-size: 1rem;
+}
+
+.token-modal-actions {
+    margin-top: 1rem;
 }
 
 .token-modal-content button {

--- a/public/admin/index.html
+++ b/public/admin/index.html
@@ -51,6 +51,7 @@
                 <div class="header-right">
                     <span class="status-indicator" id="status-indicator">●</span>
                     <span id="status-text">Connected</span>
+                    <button type="button" class="btn btn-small btn-secondary" id="change-token-button">Change token</button>
                 </div>
             </header>
 
@@ -78,13 +79,18 @@
     <div class="toast-container" id="toast-container"></div>
 
     <!-- Token Setup Modal (shown on first load) -->
-    <div class="token-modal" id="token-modal" style="display: none;">
+    <div class="token-modal" id="token-modal" style="display: none;" role="dialog" aria-modal="true" aria-labelledby="token-modal-title">
         <div class="token-modal-content">
-            <h2>Admin Authentication</h2>
-            <p>Please enter your admin token to continue:</p>
-            <input type="password" id="token-input" placeholder="Enter admin token" />
-            <button onclick="saveToken()">Continue</button>
-            <p class="token-help">The admin token should be set in your .env file as ADMIN_TOKEN</p>
+            <h2 id="token-modal-title">Admin authentication required</h2>
+            <p>Please enter your admin token to continue.</p>
+            <form id="token-form">
+                <label class="sr-only" for="token-input">Admin token</label>
+                <input type="password" id="token-input" name="token" placeholder="Enter admin token" autocomplete="off" required />
+                <div class="token-modal-actions">
+                    <button type="submit" class="btn btn-primary">Continue</button>
+                </div>
+            </form>
+            <p class="token-help">This value should match the <code>ADMIN_TOKEN</code> from your server configuration.</p>
         </div>
     </div>
 


### PR DESCRIPTION
## Summary
- add a token capture modal that opens when no admin credentials are stored and expose a change token control in the header
- centralize admin API requests so every call includes the stored bearer token and allow the test-agent SSE endpoint to receive it
- refine token modal styling with accessible helpers for the updated form layout

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_690b6ff8a18483239c0cb2f00c2ea83e