### PR TITLE
Fix Apache DirectoryIndex for chatbot Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,10 @@ RUN a2enmod setenvif
 # Configure Apache ServerName to suppress FQDN warnings
 RUN echo "ServerName localhost" >> /etc/apache2/apache2.conf
 
+# Ensure Apache always serves our PHP entrypoint instead of returning a 403
+RUN printf "DirectoryIndex index.php default.php index.html\n" > /etc/apache2/conf-available/project-directoryindex.conf \
+    && a2enconf project-directoryindex
+
 # Enable .htaccess files (AllowOverride All)
 RUN sed -i '/<Directory \/var\/www\/>/,/<\/Directory>/ s/AllowOverride None/AllowOverride All/' /etc/apache2/apache2.conf
 


### PR DESCRIPTION
## Summary
- ensure the Apache image always serves the chatbot's PHP entrypoint instead of returning a 403 when no static index is present

## Testing
- not run (docker-only change)


------
https://chatgpt.com/codex/tasks/task_e_690b7e5b9bb883239c490b5c252217f3