### PR TITLE
Add agent Test & Publish workspace panel

### DIFF
--- a/public/admin/admin.css
+++ b/public/admin/admin.css
@@ -924,6 +924,334 @@ code {
     gap: 0.75rem;
 }
 
+.workspace-tabs {
+    display: flex;
+    gap: 0.75rem;
+    padding: 1rem 2rem 0;
+    border-bottom: 1px solid var(--border-color);
+    background: var(--bg-primary);
+}
+
+.workspace-tab {
+    appearance: none;
+    border: none;
+    background: transparent;
+    color: var(--text-secondary);
+    font-weight: 600;
+    padding: 0.75rem 1.5rem;
+    border-radius: 0.75rem 0.75rem 0 0;
+    cursor: pointer;
+    transition: background 0.2s ease, color 0.2s ease;
+}
+
+.workspace-tab:hover {
+    background: var(--bg-secondary);
+    color: var(--text-primary);
+}
+
+.workspace-tab.active {
+    background: #fff;
+    color: var(--primary-color);
+    box-shadow: 0 -1px 0 #fff inset, 0 1px 2px rgba(15, 23, 42, 0.08);
+    border: 1px solid var(--border-color);
+    border-bottom-color: transparent;
+}
+
+.workspace-tab:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+}
+
+.workspace-tab-panel {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+}
+
+.workspace-tab-panel .wizard-panel {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    background: var(--bg-primary);
+}
+
+.workspace-tab-panel .wizard-panel .wizard-step-body {
+    flex: 1;
+}
+
+.workspace-tab-panel .wizard-panel .wizard-footer {
+    margin-top: auto;
+}
+
+/* ==================== Test & Publish Panel ==================== */
+
+.tester-panel {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
+    padding: 1.5rem 2rem 2rem;
+    overflow-y: auto;
+    background: var(--bg-primary);
+}
+
+.tester-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    gap: 1.5rem;
+}
+
+.tester-agent-status {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+}
+
+.tester-badge-status {
+    background: rgba(79, 70, 229, 0.12);
+    color: var(--primary-color);
+    border: 1px solid var(--primary-color);
+}
+
+.tester-card {
+    background: var(--bg-secondary);
+    border-radius: 0.75rem;
+    padding: 1.5rem;
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+    box-shadow: 0 1px 2px rgba(15, 23, 42, 0.06);
+}
+
+.tester-card-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 1rem;
+    margin-bottom: 0.5rem;
+}
+
+.tester-meta-actions {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+}
+
+.tester-prompt-meta {
+    font-size: 0.95rem;
+    color: var(--text-secondary);
+}
+
+.tester-prompt-list {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+    gap: 1rem;
+}
+
+.tester-prompt-list > div {
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+}
+
+.tester-prompt-list dt {
+    font-weight: 600;
+    font-size: 0.8rem;
+    color: var(--text-secondary);
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+}
+
+.tester-prompt-list dd {
+    margin: 0;
+    color: var(--text-primary);
+}
+
+.tester-meta-loading {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    color: var(--text-secondary);
+}
+
+.tester-chat-card {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+}
+
+.tester-chat-history {
+    background: #fff;
+    border: 1px solid var(--border-color);
+    border-radius: 0.75rem;
+    padding: 1rem;
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+    max-height: 420px;
+    overflow-y: auto;
+}
+
+.chat-row {
+    display: flex;
+}
+
+.chat-row-user {
+    justify-content: flex-end;
+}
+
+.chat-row-assistant {
+    justify-content: flex-start;
+}
+
+.chat-row-system {
+    justify-content: center;
+}
+
+.chat-bubble {
+    max-width: 78%;
+    padding: 0.75rem 1rem;
+    border-radius: 1rem;
+    font-size: 0.95rem;
+    line-height: 1.5;
+    position: relative;
+    word-break: break-word;
+}
+
+.chat-bubble-user {
+    background: var(--primary-color);
+    color: #fff;
+    border-bottom-right-radius: 0.25rem;
+}
+
+.chat-bubble-assistant {
+    background: var(--bg-primary);
+    border: 1px solid var(--border-color);
+    color: var(--text-primary);
+    border-bottom-left-radius: 0.25rem;
+}
+
+.chat-bubble-system {
+    background: rgba(79, 70, 229, 0.08);
+    color: var(--primary-color);
+    border-radius: 999px;
+    font-size: 0.85rem;
+}
+
+.chat-bubble.streaming {
+    padding-right: 2.25rem;
+}
+
+.chat-stream-indicator {
+    position: absolute;
+    right: 0.75rem;
+    bottom: 0.75rem;
+    display: flex;
+    align-items: center;
+}
+
+.tester-input-card textarea {
+    resize: vertical;
+    min-height: 120px;
+}
+
+.tester-input-actions {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 1rem;
+    flex-wrap: wrap;
+}
+
+.tester-send-group {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+}
+
+.tester-status-message {
+    font-size: 0.9rem;
+}
+
+.tester-status {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    font-size: 0.9rem;
+}
+
+.tester-status-success {
+    color: #0f9d58;
+}
+
+.tester-status-error {
+    color: #ef4444;
+}
+
+.tester-status-streaming {
+    color: var(--primary-color);
+}
+
+.tester-publish-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+}
+
+.tester-feedback {
+    margin-top: 0.5rem;
+    min-height: 1.25rem;
+}
+
+.tester-feedback-message {
+    padding: 0.75rem 1rem;
+    border-radius: 0.75rem;
+    font-size: 0.9rem;
+}
+
+.tester-feedback-message.is-success {
+    background: rgba(16, 185, 129, 0.12);
+    color: #047857;
+}
+
+.tester-feedback-message.is-error {
+    background: rgba(239, 68, 68, 0.12);
+    color: #b91c1c;
+}
+
+.tester-empty-state,
+.tester-empty-hint {
+    text-align: center;
+    color: var(--text-secondary);
+}
+
+.tester-empty-state {
+    padding: 2rem;
+    border: 1px dashed var(--border-color);
+    border-radius: 0.75rem;
+    background: var(--bg-secondary);
+}
+
+.tester-empty-state h3 {
+    margin-bottom: 0.5rem;
+    font-weight: 600;
+}
+
+.tester-empty-hint {
+    font-size: 0.9rem;
+    padding: 1.5rem 1rem;
+    background: rgba(15, 23, 42, 0.02);
+    border-radius: 0.75rem;
+}
+
+.spinner-inline {
+    width: 16px;
+    height: 16px;
+    border-width: 2px;
+}
+
 .wizard-review-summary {
     background: #fff;
     border-radius: 0.75rem;

--- a/public/admin/admin.js
+++ b/public/admin/admin.js
@@ -911,70 +911,11 @@ async function makeDefaultAgent(id) {
     }
 }
 
-async function testAgent(id) {
-    const message = prompt('Enter a test message:', 'Hello, can you help me?');
-    if (!message) return;
-    
-    const content = `
-        <div class="form-group">
-            <label class="form-label">Test Message</label>
-            <div style="padding: 1rem; background: #f3f4f6; border-radius: 0.375rem; margin-bottom: 1rem;">
-                ${message}
-            </div>
-        </div>
-        
-        <div class="form-group">
-            <label class="form-label">Agent Response</label>
-            <div id="test-response" style="padding: 1rem; background: #f3f4f6; border-radius: 0.375rem; min-height: 100px; max-height: 400px; overflow-y: auto;">
-                <div class="spinner"></div> Streaming response...
-            </div>
-        </div>
-        
-        <div class="modal-footer">
-            <button class="btn btn-secondary" onclick="closeModal()">Close</button>
-        </div>
-    `;
-    
-    openModal('Test Agent', content);
-    
-    // Start streaming response
-    const responseDiv = document.getElementById('test-response');
-    responseDiv.innerHTML = '';
-    
-    try {
-        const url = api.testAgent(id);
-        const eventSource = new EventSource(url);
-        
-        let fullResponse = '';
-        
-        eventSource.addEventListener('message', (event) => {
-            try {
-                const data = JSON.parse(event.data);
-                
-                if (data.type === 'start') {
-                    responseDiv.innerHTML = `<div style="color: #6b7280; font-size: 0.875rem; margin-bottom: 0.5rem;">Testing agent: ${data.agent_name}</div>`;
-                } else if (data.type === 'chunk') {
-                    fullResponse += data.content || '';
-                    responseDiv.innerHTML += (data.content || '').replace(/\n/g, '<br>');
-                    responseDiv.scrollTop = responseDiv.scrollHeight;
-                } else if (data.type === 'done') {
-                    eventSource.close();
-                    responseDiv.innerHTML += '<div style="color: #10b981; font-size: 0.875rem; margin-top: 0.5rem;">✓ Response complete</div>';
-                } else if (data.type === 'error') {
-                    eventSource.close();
-                    responseDiv.innerHTML += `<div style="color: #ef4444;">Error: ${data.message}</div>`;
-                }
-            } catch (error) {
-                console.error('Error parsing SSE:', error);
-            }
-        });
-        
-        eventSource.onerror = () => {
-            eventSource.close();
-            responseDiv.innerHTML += '<div style="color: #ef4444;">Connection error</div>';
-        };
-    } catch (error) {
-        responseDiv.innerHTML = `<div style="color: #ef4444;">Error: ${error.message}</div>`;
+function testAgent(id) {
+    if (window.agentTester && typeof window.agentTester.start === 'function') {
+        window.agentTester.start(id);
+    } else {
+        showToast('Painel de teste indisponível no momento.', 'error');
     }
 }
 


### PR DESCRIPTION
## Summary
- add a Test & Publish tab to the agent workspace with an SSE-powered chat tester and stateful history
- surface prompt metadata, reset controls, and inline status/default actions that call the admin API
- refresh the admin styles for the new tester panel and hook the legacy Test button into the workspace

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6915060231f48323a3146fe23a31f24c)